### PR TITLE
Proposed rewording for propertyoverwrite PR 216

### DIFF
--- a/samples/application-conf/application.properties
+++ b/samples/application-conf/application.properties
@@ -58,46 +58,50 @@ jobCard=
 ###############################################################
 # Build Property management
 ###############################################################
-#
-# zAppBuild is equipped to set build properties from individual property files for the file being
-# built (i.e., build file). Typical usage scenario for using this capability is to overwrite
-# compile or link options, managing them in individual property files. Using this approach might
-# ease the migration of properties from the previous build system rather than using the DBB inherent
-# capability of using File property path patterns.
 # 
 # zAppBuild allows you to manage default properties and file properties:
+#
+# - Default build properties are defined in the /build-conf and /application-conf property files (e.g. Cobol.properties)
 #  
-#  Default Build properties
-#     which are defined in /build-conf and in /application-conf property files (i.e. Cobol.properties)
-#  
-#  File properties are defined through one of two methods:
-#    - Overwrites for groups or individual files 
-#      typically defined in file.properties using the DBB file property path syntax
-#      see: https://www.ibm.com/docs/en/dbb/1.1.0?topic=scripts-how-organize-build-script#file-properties
-#    - Overwrites through individual property files
-#      being located in a configurable subfolder (i.e. properties/epsmlist.cbl.properties)
+# - File properties override corresponding default build properties, and are defined through one of two methods:
+#   - Overwrites for groups or individual files 
+#     - Typically defined in file.properties using the DBB file property path syntax
+#     - See: https://www.ibm.com/docs/en/dbb/1.1.0?topic=scripts-how-organize-build-script#file-properties
+#   - Overwrites for an individual file
+#     - Defined in an individual property file located in a configurable subfolder (e.g. properties/epsmlist.cbl.properties)
 #
-# Individual property files are resolved within the pattern <propertyFilePath directory>/<buildFile>.<propertyFileExtension>, e.q.
-#  for the build file epsmlist.cbl the process searches for a file in the propertyFilePath directory
-#  with the naming convention epsmlist.cbl.properties.
-#  If no property file is found, the build will take the default values or potentially already defined file properties.
+# A typical scenario for using zAppBuild's capability to set build properties for an individual source file via a corresponding
+# individual property file is to overwrite compile or link options. This approach might help ease the migration of properties
+# from the previous build system.
 #
-# Please be aware, that overwrites for a specific build property should be seen as exclusively managed in either the file property path syntax or
-#  in the individual property files. The following section gives an example how both approaches can be combined:
+# Individual property files are resolved using the pattern <propertyFilePath directory>/<sourceFile>.<propertyFileExtension>. For example,
+#  for the source file epsmlist.cbl, the process searches for a file in the propertyFilePath directory
+#  with the name epsmlist.cbl.properties.
+#  If no corresponding property file is found, the build will use the default build values. (Or, if any file properties were defined
+#  using the DBB file property path syntax, then the build will use those.)
 #
-# You can use a file property path syntax to define a file property for a group of files. The below defines the deployType for
-#  all build files in the folder cobol beginning with AB* to be BATCHLOAD:
+# Note: Overwrites for a specific build property should be managed either via the file property path syntax or
+#  in the individual property files, but not both. The following example shows how both approaches for defining
+#  file properties can be combined to specify a set of build properties for the same source file:
+#
+# ### Example: Using the file property path syntax and individual property files to define build properties for a source file named app/cobol/AB123456.cbl
+# - You can use the file property path syntax to define a file property for a group of files. The below defines the deployType for
+#  all source files in the folder cobol beginning with AB* to be BATCHLOAD:
 #
 #  cobol_deployType = BATCHLOAD :: **/cobol/AB*.cbl
 #
-# While you define a individual file property file for app/cobol/AB123456.cbl containing
+# - At the same time, you can define an individual file property file for app/cobol/AB123456.cbl with the following build property:
 #  
-#  cobol_compileParms = LIB,SOURCE   
+#  cobol_compileParms = LIB,SOURCE
+# 
+# - During the build, the file app/cobol/AB123456.cbl will have the deployType BATCHLOAD and the COBOL compile parameters LIB and SOURCE.
+# ### End example ###
 
-#
-# flag to enable the zAppBuild capability to load individual property files for a build file, default: false
-# It is recommended to use a file property path syntax to activate the loading of property files for a group of files,
-# while not all types in the repository. See above sample. 
+# ### Properties to enable and configure build property overwrites using individual property files
+
+# flag to enable the zAppBuild capability to load individual property files for individual source files, default: false
+# Note: To activate the loading of property files for a group of files, it is recommended to use the file property path
+# syntax instead. (See above example with **/cobol/AB*.cbl.)
 loadFileLevelProperties=false
 
 # relative path to folder containing individual property files


### PR DESCRIPTION
Summary of changes:
- Moved up the descriptions of default and file properties (as the section has the more general title of "Build Property management").
- Replaced the term "build file" with "source file". ("Build file" makes me think of `build.groovy`, but please let me know if that is a standard term for referring to the source files that get built.)
- Formatting and rewording revisions to clarify the explanations and examples.

If this rewording is accepted, then we can also copy/paste the contents into `samples/MortgageApplication/application-conf/application.properties`.